### PR TITLE
Update to use Node 16 instead of 12.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,5 +12,5 @@ inputs:
     description: 'Github generated token'
     required: true
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Reference: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/